### PR TITLE
Add missing dot to yml file extension

### DIFF
--- a/AzSentinel/Public/Import-AzSentinelAlertRule.ps1
+++ b/AzSentinel/Public/Import-AzSentinelAlertRule.ps1
@@ -93,7 +93,7 @@ function Import-AzSentinelAlertRule {
                 Write-Error -Message 'Unable to convert JSON file' -ErrorAction Stop
             }
         }
-        elseif ($SettingsFile.Extension -in '.yaml', 'yml') {
+        elseif ($SettingsFile.Extension -in '.yaml', '.yml') {
             try {
                 $analytics = [pscustomobject](Get-Content $SettingsFile -Raw | ConvertFrom-Yaml -ErrorAction Stop)
                 $analytics | Add-Member -MemberType NoteProperty -Name DisplayName -Value $analytics.name
@@ -103,6 +103,8 @@ function Import-AzSentinelAlertRule {
                 Write-Verbose $_
                 Write-Error -Message 'Unable to convert yaml file' -ErrorAction Stop
             }
+        } else {
+            Write-Error -Message 'Unsupported extension for SettingsFile' -ErrorAction Stop
         }
 
         foreach ($item in $analytics) {


### PR DESCRIPTION
# Summary of the Pull Request
The Import-AZSentinelAlertRule function is not able to import `yml` files due
to missing dot in the file extension.

## References
Didn't create a issue for this since it was such a small change.

## PR Checklist

**By submitting this pull request, I confirm the following:**

*please fill any appropriate checkboxes, e.g: [X]*

- [ ] Closes #xxx
- [ ] Requires documentation to be updated
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] It is compatible with the [MIT License](https://opensource.org/licenses/MIT)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
It is a super small change.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I have not been able to test the code since I am missing access to the environment I found this issue in but felt it was small enough to fix without testing it in the full environment.

## How does this PR accomplish the above
Please see diff.

## What documentation changes (if any) are needed to support this PR
No change in documentation is needed.

