### PR TITLE
Filter rules by lastModified date

### DIFF
--- a/AzSentinel/Public/Get-AzSentinelAlertRule.ps1
+++ b/AzSentinel/Public/Get-AzSentinelAlertRule.ps1
@@ -15,9 +15,14 @@ function Get-AzSentinelAlertRule {
       Enter the name of the Alert rule
       .PARAMETER Kind
       The alert rule kind
+      .PARAMETER LastModified
+      Filter for rules modified after this date/time
       .EXAMPLE
       Get-AzSentinelAlertRule -WorkspaceName "" -RuleName "",""
       In this example you can get configuration of multiple alert rules in once
+      .EXAMPLE
+      Get-LogAnalyticWorkspace -SubscriptionId "" -WorkspaceName "" -LastModified 2020-09-21
+      In this example you can get configuration of multiple alert rules only if modified after the 21st September 2020. The datetime must be in ISO8601 format.
     #>
 
     [cmdletbinding(SupportsShouldProcess)]
@@ -39,7 +44,12 @@ function Get-AzSentinelAlertRule {
         [Parameter(Mandatory = $false,
             ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
-        [Kind[]]$Kind
+        [Kind[]]$Kind,
+
+        [Parameter(Mandatory = $false,
+            ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
+        [DateTime]$LastModified
     )
 
     begin {
@@ -74,6 +84,10 @@ function Get-AzSentinelAlertRule {
         }
 
         $return = @()
+        if ($alertRules.value -and $LastModified) {
+            Write-Verbose "Filtering for rules modified after $LastModified"
+            $alertRules.value = $alertRules.value | Where-Object { $_.properties.lastModifiedUtc -gt $LastModified }
+        }
         if ($alertRules.value) {
             Write-Verbose "Found $($alertRules.value.count) Alert rules"
 

--- a/AzSentinel/docs/Get-AzSentinelAlertRule.md
+++ b/AzSentinel/docs/Get-AzSentinelAlertRule.md
@@ -14,7 +14,7 @@ Get Azure Sentinel Alert Rules
 
 ```
 Get-AzSentinelAlertRule [-SubscriptionId <String>] -WorkspaceName <String> [-RuleName <String[]>]
- [-Kind <Kind[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Kind <Kind[]>] [-LastModified <DateTime>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,6 +26,12 @@ With this function you can get the configuration of the Azure Sentinel Alert rul
 ```
 Get-AzSentinelAlertRule -WorkspaceName "" -RuleName "",""
 In this example you can get configuration of multiple alert rules in once
+```
+
+### EXAMPLE 2
+```
+Get-LogAnalyticWorkspace -SubscriptionId "" -WorkspaceName "" -LastModified 2020-09-21
+In this example you can get configuration of multiple alert rules only if modified after the 21st September 2020. The datetime must be in ISO8601 format.
 ```
 
 ## PARAMETERS
@@ -83,6 +89,21 @@ Type: Kind[]
 Parameter Sets: (All)
 Aliases:
 Accepted values: Scheduled, Fusion, MLBehaviorAnalytics, MicrosoftSecurityIncidentCreation
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -LastModified
+The minimum lastModified time to return
+
+```yaml
+Type: DateTime
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/Get-AzSentinelAlertRule.md
+++ b/docs/Get-AzSentinelAlertRule.md
@@ -14,7 +14,7 @@ Get Azure Sentinel Alert Rules
 
 ```
 Get-AzSentinelAlertRule [-SubscriptionId <String>] -WorkspaceName <String> [-RuleName <String[]>]
- [-Kind <Kind[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Kind <Kind[]>] [-LastModified <DateTime>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,6 +26,12 @@ With this function you can get the configuration of the Azure Sentinel Alert rul
 ```
 Get-AzSentinelAlertRule -WorkspaceName "" -RuleName "",""
 In this example you can get configuration of multiple alert rules in once
+```
+
+### EXAMPLE 2
+```
+Get-LogAnalyticWorkspace -SubscriptionId "" -WorkspaceName "" -LastModified 2020-09-21
+In this example you can get configuration of multiple alert rules only if modified after the 21st September 2020. The datetime must be in ISO8601 format.
 ```
 
 ## PARAMETERS
@@ -83,6 +89,21 @@ Type: Kind[]
 Parameter Sets: (All)
 Aliases:
 Accepted values: Scheduled, Fusion, MLBehaviorAnalytics, MicrosoftSecurityIncidentCreation
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -LastModified
+The minimum lastModified time to return
+
+```yaml
+Type: DateTime
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
# Summary of the Pull Request

This PR adds an optional `LastModified` parameter to the `Get-AzSentinelAlertRule` function allowing users to filter for rules modified after a specified date/time.

The requirement for this was driven by our CI pipeline beginning to crawl when Sentinel rules get into the mid to high 100's. This PR filters rules *before* the code starts attempting to pull additional details for each rule (`Get-AzSentinelAlertRuleAction`).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

**By submitting this pull request, I confirm the following:**

*please fill any appropriate checkboxes, e.g: [X]*

- [X] Requires documentation to be updated
- [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] It is compatible with the [MIT License](https://opensource.org/licenses/MIT)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

