### PR TITLE
Follow official api schema

### DIFF
--- a/AzSentinel/Classes/groupingConfiguration.ps1
+++ b/AzSentinel/Classes/groupingConfiguration.ps1
@@ -1,5 +1,5 @@
 class GroupingConfiguration {
-    [bool]$Enabled
+    [bool]$enabled
 
     [bool]$reopenClosedIncident
 
@@ -27,7 +27,7 @@ class GroupingConfiguration {
         return $value
     }
 
-    groupingConfiguration ($properties) {
+    GroupingConfiguration ($properties) {
         $this.enabled = $properties.enabled
         $this.reopenClosedIncident = $properties.reopenClosedIncident
         $this.lookbackDuration = $properties.lookbackDuration
@@ -35,8 +35,8 @@ class GroupingConfiguration {
         $this.groupByEntities = $properties.groupByEntities
     }
 
-    groupingConfiguration ($Enabled, $reopenClosedIncident, $lookbackDuration, $entitiesMatchingMethod, $groupByEntities) {
-        $this.enabled = if ($null -ne $Enabled ) { $Enabled } else { $false }
+    GroupingConfiguration ($enabled, $reopenClosedIncident, $lookbackDuration, $entitiesMatchingMethod, $groupByEntities) {
+        $this.enabled = if ($null -ne $enabled ) { $enabled } else { $false }
         $this.reopenClosedIncident = if ($null -ne $reopenClosedIncident) { $reopenClosedIncident } else { $false }
         $this.lookbackDuration = if ($lookbackDuration) { [groupingConfiguration]::TimeString($lookbackDuration) } else { "PT5H" }
         $this.entitiesMatchingMethod = if ($entitiesMatchingMethod) { $entitiesMatchingMethod } else { "All" }

--- a/AzSentinel/Public/Import-AzSentinelAlertRule.ps1
+++ b/AzSentinel/Public/Import-AzSentinelAlertRule.ps1
@@ -135,6 +135,7 @@ function Import-AzSentinelAlertRule {
         elseif ($rules.Scheduled){
             $scheduled = $rules.Scheduled
         }
+        # Take the raw rule configuration if it is not nested in "analytics", "Scheduled", "fusion", "MLBehaviorAnalytics" or "MicrosoftIncidentCreation"
         else{
             $scheduled = $rules
         }

--- a/AzSentinel/Public/Import-AzSentinelAlertRule.ps1
+++ b/AzSentinel/Public/Import-AzSentinelAlertRule.ps1
@@ -157,16 +157,17 @@ function Import-AzSentinelAlertRule {
                 $uri = "$script:baseUri/providers/Microsoft.SecurityInsights/alertRules/$($guid)?api-version=2019-01-01-preview"
             }
 
+            # The official API schema indicates that the grouping configuration is part of the incident configuration
             try {
                 $groupingConfiguration = [GroupingConfiguration]::new(
-                    $item.groupingConfiguration.enabled,
-                    $item.groupingConfiguration.reopenClosedIncident,
-                    $item.groupingConfiguration.lookbackDuration,
-                    $item.groupingConfiguration.entitiesMatchingMethod,
-                    $item.groupingConfiguration.groupByEntities
+                    $item.incidentConfiguration.groupingConfiguration.enabled,
+                    $item.incidentConfiguration.groupingConfiguration.reopenClosedIncident,
+                    $item.incidentConfiguration.groupingConfiguration.lookbackDuration,
+                    $item.incidentConfiguration.groupingConfiguration.entitiesMatchingMethod,
+                    $item.incidentConfiguration.groupingConfiguration.groupByEntities
                 )
-                $IncidentConfiguration = [IncidentConfiguration]::new(
-                    $item.createIncident,
+                $incidentConfiguration = [IncidentConfiguration]::new(
+                    $item.incidentConfiguration.createIncident,
                     $groupingConfiguration
                 )
 
@@ -193,7 +194,7 @@ function Import-AzSentinelAlertRule {
                         $item.suppressionEnabled,
                         $item.Tactics,
                         $item.playbookName,
-                        $IncidentConfiguration,
+                        $incidentConfiguration,
                         $item.aggregationKind,
                         $item.AlertRuleTemplateName
                     )
@@ -213,7 +214,7 @@ function Import-AzSentinelAlertRule {
                         $item.suppressionEnabled,
                         $item.Tactics,
                         $item.playbookName,
-                        $IncidentConfiguration,
+                        $incidentConfiguration,
                         $item.aggregationKind
                     )
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
# Summary of the Pull Request

This PR makes the Import-AzSentinelAlertRule cmdlet follow the official API schema for analytic rules were the GroupingConfiguration is nested within the IncidentConfiguration.
This PR also makes it possible to import a "raw" settings file without nesting the configuration within the modules root schema.

Both of these changes makes the module more usable as the configuration files don't need to be updated to cohere with the module.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? -->
## References

Official API documentation: [https://github.com/Azure/azure-rest-api-specs/blob/master/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/preview/2019-01-01-preview/examples/alertRules/CreateScheduledAlertRule.json](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/preview/2019-01-01-preview/examples/alertRules/CreateScheduledAlertRule.json)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

**By submitting this pull request, I confirm the following:**

*please fill any appropriate checkboxes, e.g: [X]*

- [ ] Closes #xxx
- [X] Requires documentation to be updated
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
- [ ] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] It is compatible with the [MIT License](https://opensource.org/licenses/MIT)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

*A detailed description, screenshots (if necessary), as well as links to any relevant issues*

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Created an analytic rule in yaml with the GroupingConfiguration nested within the IncidentConfiguration:

```YAML
displayName: Conditional Access Policy Created
description: |
  Monitors the creation of conditional access policies. Adversaries may create conditional access policies to prevent legitimate users from accessing systems, or to bypass existing protection mechanisms.
severity: Medium
enabled: true
requiredDataConnectors:
  - connectorId: AzureActiveDirectory
    dataTypes:
      - AuditLogs
queryFrequency: 30M
queryPeriod: 30M
triggerOperator: GreaterThan
triggerThreshold: 0
tactics:
  - DefenseEvasion
  - CredentialAccess
relevantTechniques:
  - T1556
suppressionEnabled: false
suppressionDuration: PT1H
incidentConfiguration:
  createIncident: true
  groupingConfiguration:
    enabled: true
    reopenClosedIncident: false
    lookbackDuration: "PT8H"
    entitiesMatchingMethod: "Custom"
    groupByEntities:
      - Account
query: |
  AuditLogs
  | where OperationName =~ "Add policy"
  | where Result =~ "success"
  | where parse_json(tostring(TargetResources[0].modifiedProperties[1].newValue)) contains "ConditionalAccess"
  | extend
      userPrincipalName = tostring(InitiatedBy.user.userPrincipalName),
      ipAddress = tostring(InitiatedBy.user.ipAddress),
      policyName = parse_json(tostring(TargetResources[0].displayName))
  | project TimeGenerated, userPrincipalName, ipAddress, policyName, Result
  | extend AccountCustomEntity = userPrincipalName, IPCustomEntity = ipAddress
```
  

- Imported it with the current version of AzSentinel and noticed that the specified Incident Configuration settings was not set accordingly.

- Updated the Import-AzSentinelAlertRule cmdlet with the updates in this PR
- Deployed the rule again and verified that it respected the incident configuration settings

## How does this PR accomplish the above

The only real change that was needed was to add additional depth when specifying the GroupingConfiguration and the IncidentConfiguration, as below:
![image](https://user-images.githubusercontent.com/36885853/102775822-e8326a80-438d-11eb-9dfd-796ef780b4c6.png)


## What documentation changes (if any) are needed to support this PR

The Schema needs to be updated accordingly:
### Scheduled rule

```JSON
{
    "displayName": "string",
    "description": "string",
    "AlertRuleTemplateName": "string",
    "severity": "High",
    "enabled": true,
    "query": "SecurityEvent | where EventID == \"4688\" | where CommandLine contains \"-noni -ep bypass $\"",
    "queryFrequency": "5H",
    "queryPeriod": "5H",
    "triggerOperator": "GreaterThan",
    "triggerThreshold": 5,
    "suppressionDuration": "6H",
    "suppressionEnabled": false,
    "tactics": [
        "Persistence",
        "LateralMovement",
        "Collection"
    ],
    "playbookName": "string",
    "aggregationKind": "string",
    **"incidentConfiguration": {
        "createIncident": true,
        "groupingConfiguration": {
            "enabled": true,
            "reopenClosedIncident": false,
            "lookbackDuration": "PT5H",
            "entitiesMatchingMethod": "Custom",
            "groupByEntities": [
                "Host",
                "Account",
                "Ip",
                "Url",
                "FileHash"
            ]
        }
    }**
}
```

---

* You must follow the template instructions. Failure to do so will result in your pull request being closed.
