### PR TITLE
Added fixed for case sensitive split and missing workspace name from …

### DIFF
--- a/AzSentinel/Public/Set-AzSentinel.ps1
+++ b/AzSentinel/Public/Set-AzSentinel.ps1
@@ -102,27 +102,28 @@ function Set-AzSentinel {
                     'workspaceResourceId' = $workspaceResult.id
                 }
                 'plan'       = @{
-                    'name'          = 'SecurityInsights($workspace)'
+                    'name'          = "SecurityInsights($($workspaceResult.name))"  # Changed to include the actual workspace
                     'publisher'     = 'Microsoft'
                     'product'       = 'OMSGallery/SecurityInsights'
                     'promotionCode' = ''
                 }
             }
-            $uri = "$(($Script:baseUri).Split('microsoft.operationalinsights')[0])Microsoft.OperationsManagement/solutions/SecurityInsights($WorkspaceName)?api-version=2015-11-01-preview"
+            $splittedBaseUri = ($Script:baseUri -split 'microsoft.operationalinsights')[0] #Using -split is case insensitive.
+            $uri = "$($splittedBaseUri)/Microsoft.OperationsManagement/solutions/SecurityInsights($WorkspaceName)?api-version=2015-11-01-preview"
 
             try {
-                $solutionResult = Invoke-webrequest -Uri $uri -Method Get -Headers $script:authHeader
+                $solutionResult = Invoke-WebRequest -Uri $uri -Method Get -Headers $script:authHeader
                 Write-Output "Azure Sentinel is already enabled on $WorkspaceName and status is: $($solutionResult.StatusDescription)"
             }
             catch {
                 $errorReturn = $_
                 $errorResult = ($errorReturn | ConvertFrom-Json ).error
                 if ($errorResult.Code -eq 'ResourceNotFound') {
-                    Write-Output "Azure Sentinetal is not enabled on workspace: $($WorkspaceName)"
+                    Write-Output "Azure Sentinel is not enabled on workspace: $($WorkspaceName)"
                     try {
                         if ($PSCmdlet.ShouldProcess("Do you want to enable Sentinel for Workspace: $workspace")) {
-                            $result = Invoke-webrequest -Uri $uri -Method Put -Headers $script:authHeader -Body ($body | ConvertTo-Json)
-                            Write-Output "Successfully enabled Sentinel on workspae: $WorkspaceName with result code $($result.StatusDescription)"
+                            $result = Invoke-WebRequest -Uri $uri -Method Put -Headers $script:authHeader -Body ($body | ConvertTo-Json)
+                            Write-Output "Successfully enabled Sentinel on workspace: $WorkspaceName with result code $($result.StatusDescription)"
                         }
                         else {
                             Write-Output "No change have been made for $WorkspaceName, deployment aborted"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
# Summary of the Pull Request
There was a small issue in enabling Sentinel on a workspace. Another user also opened an issue for this #192 

- The body of the request contained the text ($workspace) and not the actual workspace resource ID
- The retrieval of the workspace failed as the splitting of the baseURL failed. Using $var.split("") is case sensitive. Switched to $var -split ("") as this is case insensitive and should prevent any issues.
- fixed 2 small typo's in output
...

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

**By submitting this pull request, I confirm the following:**

*please fill any appropriate checkboxes, e.g: [X]*

- [X] Closes #192
- [X] Requires documentation to be updated (N/A)
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] It is compatible with the [MIT License](https://opensource.org/licenses/MIT)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---

## Detailed Description of the Pull Request / Additional comments

There was a small issue in enabling Sentinel on a workspace. Another user also opened an issue for this #192 

- The body of the request contained the text ($workspace) and not the actual workspace resource ID. This is because $workspace was between single quotes
- The retrieval of the workspace failed as the splitting of the baseURL failed. Using $baseUri.split("") is case sensitive. Switched to $baseUri -split ("") as this is case insensitive and should prevent any issues.
- Fixed 2 small typo's in output (Sentinetal vs Sentinel)

## Validation Steps Performed

```powershell
$workspace = New-AzOperationalInsightsWorkspace -location 'southeastasia' -Name 'azla-sentinel' -
Sku 'PerGB2018' -ResourceGroupName 'azrg-sentinel' -Tag @{environment = 'Development'}

Set-AzSentinel -WorkspaceName $workspace.Name -confirm:$false
```

## How does this PR accomplish the above

Prevents the 400 error code issue

